### PR TITLE
Improve form validation (SNAPSHOT branch)

### DIFF
--- a/app/views/createForm.scala.html
+++ b/app/views/createForm.scala.html
@@ -10,8 +10,8 @@
         
         <fieldset>
             @inputText(computerForm("name"), '_label -> "Computer name", '_help -> "")
-            @inputText(computerForm("introduced"), '_label -> "Introduced date", 'type -> "date", '_help -> "")
-            @inputText(computerForm("discontinued"), '_label -> "Discontinued date", 'type -> "date", '_help -> "")
+            @inputText(computerForm("introduced"), '_label -> "Introduced date", '_help -> "")
+            @inputText(computerForm("discontinued"), '_label -> "Discontinued date", '_help -> "")
 
             @select(
                 computerForm("company.id"), 

--- a/app/views/editForm.scala.html
+++ b/app/views/editForm.scala.html
@@ -11,8 +11,8 @@
         <fieldset>
         
             @inputText(computerForm("name"), '_label -> "Computer name", '_help -> "")
-            @inputText(computerForm("introduced"), '_label -> "Introduced date", 'type -> "date", '_help -> "")
-            @inputText(computerForm("discontinued"), '_label -> "Discontinued date", 'type -> "date", '_help -> "")
+            @inputText(computerForm("introduced"), '_label -> "Introduced date", '_help -> "")
+            @inputText(computerForm("discontinued"), '_label -> "Discontinued date", '_help -> "")
             
             @select(
                 computerForm("company.id"), 

--- a/test/FunctionalTest.java
+++ b/test/FunctionalTest.java
@@ -84,8 +84,8 @@ public class FunctionalTest {
 
         assertThat(result.status(), equalTo(Helpers.BAD_REQUEST));
         assertThat(Helpers.contentAsString(result), containsString("<option value=\"1\" selected=\"selected\">Apple Inc.</option>"));
-        //  <input type="date" id="introduced" name="introduced" value="badbadbad" aria-describedby="introduced_info_0 introduced_error_0" aria-invalid="true" class="form-control">
-        assertThat(Helpers.contentAsString(result), containsString("<input type=\"date\" id=\"introduced\" name=\"introduced\" value=\"badbadbad\" "));
+        //  <input type="text" id="introduced" name="introduced" value="badbadbad" aria-describedby="introduced_info_0 introduced_error_0" aria-invalid="true" class="form-control">
+        assertThat(Helpers.contentAsString(result), containsString("<input type=\"text\" id=\"introduced\" name=\"introduced\" value=\"badbadbad\" "));
         // <input type="text" id="name" name="name" value="FooBar" aria-describedby="name_info_0" required="true" class="form-control">
         assertThat(Helpers.contentAsString(result), containsString("<input type=\"text\" id=\"name\" name=\"name\" value=\"FooBar\" "));
 

--- a/test/IntegrationTest.java
+++ b/test/IntegrationTest.java
@@ -32,6 +32,18 @@ public class IntegrationTest {
             browser.$("#discontinued").fill().with("10-10-2001");
             browser.$("input.primary").click();
 
+            assertThat(browser.$("dl.error").size(), equalTo(1));
+            assertThat(browser.$("dl.error label").first().text() ,equalTo("Discontinued date"));
+
+            browser.$("#discontinued").fill().with("xxx");
+            browser.$("input.primary").click();
+
+            assertThat(browser.$("dl.error").size(), equalTo(1));
+            assertThat(browser.$("dl.error label").first().text(), equalTo("Discontinued date"));
+
+            browser.$("#discontinued").fill().with("");
+            browser.$("input.primary").click();
+
             assertThat(browser.$("section h1").first().text(), equalTo("574 computers found"));
             assertThat(browser.$(".alert-message").first().text(), equalTo("Done! Computer Apple II has been updated"));
 


### PR DESCRIPTION
Two related changes are proposed:

1. date-type input elements are not supported by all browsers (see http://caniuse.com/#feat=input-datetime). After setting wrong text (e.g. "xxx") in Selenium test, Firefox sends it to the server (Firefox does not support date-type inputs), but HtmlUnit sends empty text. There are two such fields in the project - "Introduced date" and "Discontinued date" in computer creation/edition form.

2. server-side form validation testing code (in IntegrationTest) was removed accidentally(?) during project migration to Play! 2.5.x (commit https://github.com/playframework/play-java-ebean-example/commit/0fd5663188f326d88be00eafe390e843e8330064#diff-0c0b9b13cca77d9ddde990e265217b23)

When restoring validation code, changing date-type inputs to text-type ones is required to pass any entered text to the server for server-side validation of the form.

After merging this PR, apply similar changes to master branch.